### PR TITLE
Pointing .gitmodules file at thirddegree HatchitGame repository.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	url = https://github.com/thirddegree/tinyxml2.git
 [submodule "HatchitGame"]
 	path = HatchitGame
-	url = https://github.com/tcreeds/HatchitGame.git
+	url = https://github.com/thirddegree/HatchitGame.git
 [submodule "HatchitMath"]
 	path = HatchitMath
 	url = https://github.com/thirddegree/HatchitMath.git


### PR DESCRIPTION
I think this got committed when the JSON library was added. Updating to point back at the thirddegree repo for HatchitGame.
