### PR TITLE
Changed Scene JSON format.

### DIFF
--- a/Assets/Scenes/testscene.json
+++ b/Assets/Scenes/testscene.json
@@ -9,9 +9,6 @@
         {
             "Name": "ParentObject",
             "GUID": "{00000000-0000-0000-0000-000000000001}",
-            "Children": [
-                "{00000000-0000-0000-0000-000000000002}"
-            ],
             "Components": [
                 {
                     "Name": "MeshRenderer"
@@ -26,6 +23,7 @@
         {
             "Name": "ChildObject",
             "GUID": "{00000000-0000-0000-0000-000000000002}",
+            "Parent": "{00000000-0000-0000-0000-000000000001}",
             "Components": [
                 {
                     "Name": "MeshRenderer"


### PR DESCRIPTION
Per Dave's suggestion, I changed GameObjects so that they had a "Parent"
attribute which represented the Guid of their parent. Previously they
contained an attribute "Children" which was an array of the child
GameObject Guids. This tweak prevents GameObjects from having multiple
parents in the JSON file.

There will be accompanying change in HatchitGame that should be merged with this.
